### PR TITLE
Add support for cloning with ssh #197

### DIFF
--- a/frigg/builds/migrations/0024_project_should_clone_with_ssh.py
+++ b/frigg/builds/migrations/0024_project_should_clone_with_ssh.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('builds', '0023_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='should_clone_with_ssh',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/frigg/builds/test_models.py
+++ b/frigg/builds/test_models.py
@@ -21,12 +21,19 @@ class ProjectTestCase(TestCase):
         project = Project.objects.create(owner='frigg', name='frigg-worker')
         self.assertEqual(str(project), 'frigg / frigg-worker')
 
-    @mock.patch('frigg.builds.models.Project.github_token', '')
-    def test_clone_url(self):
+    def test_clone_url_public(self):
         project = Project(owner='frigg', name='frigg-worker', private=False)
-        self.assertEqual(project.clone_url, 'https://github.com/frigg/frigg-worker')
+        self.assertEqual(project.clone_url, 'https://github.com/frigg/frigg-worker.git')
+
+    @mock.patch('frigg.builds.models.Project.github_token', '')
+    def test_clone_url_private(self):
         project = Project(owner='frigg', name='chewie', private=True)
-        self.assertEqual(project.clone_url, 'https://@github.com/frigg/chewie')
+        self.assertEqual(project.clone_url, 'https://@github.com/frigg/chewie.git')
+
+    @mock.patch('frigg.builds.models.Project.github_token', '')
+    def test_clone_url_ssh(self):
+        project = Project(owner='frigg', name='chewie', should_clone_with_ssh=True)
+        self.assertEqual(project.clone_url, 'git@github.com:frigg/chewie.git')
 
     def test_last_build_number(self):
         project = Project.objects.create(owner='frigg', name='frigg-worker', private=False)

--- a/frigg/projects/serializers.py
+++ b/frigg/projects/serializers.py
@@ -16,5 +16,6 @@ class ProjectSerializer(serializers.ModelSerializer):
             'name',
             'private',
             'approved',
+            'should_clone_with_ssh',
             'builds'
         )


### PR DESCRIPTION
This requires a Docker image in the worker with a ssh key that can
access the repository.