### PR TITLE
Add support for specifying branch name to svg badges

### DIFF
--- a/frigg/projects/urls.py
+++ b/frigg/projects/urls.py
@@ -6,6 +6,10 @@ urlpatterns = [
     url(r'^projects/approve/$', views.approve_projects, name='approve_projects_overview'),
     url(r'^projects/approve/(?P<project_id>\d+)/$', views.approve_projects, name='approve_project'),
     url(r'^(?P<owner>[^/]+)/(?P<name>[^/]+).svg$', views.build_badge, name='build_badge'),
+    url(r'^(?P<owner>[^/]+)/(?P<name>[^/]+)/(?P<branch>[^/]+).svg$', views.build_badge,
+        name='build_branch_badge'),
     url(r'^(?P<owner>[^/]+)/(?P<name>[^/]+)/coverage.svg$', views.coverage_badge,
         name='coverage_badge'),
+    url(r'^(?P<owner>[^/]+)/(?P<name>[^/]+)/(?P<branch>[^/]+)/coverage.svg$', views.coverage_badge,
+        name='coverage_branch_badge'),
 ]


### PR DESCRIPTION
Should allow for urls like `/owner/project/branch.svg` and `/owner/project/branch/coverage.svg` 